### PR TITLE
Allow inheritance in error classes.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -15,7 +15,8 @@ function extend(obj /*, obj2, obj3, ... */) {
 }
 
 //**createCustomError** returns the constructor for a custom error type.
-function createCustomError(name, init) {
+function createCustomError(name, init, Base) {
+    Base = Base || Error;
     assert(name, 'You are trying to register an invalid error');
     var CustomError = function() {
         Error.call(this);
@@ -27,7 +28,7 @@ function createCustomError(name, init) {
             this.message = arguments[0];
         }
     };
-    util.inherits(CustomError, Error);
+    util.inherits(CustomError, Base);
     return CustomError;
 }
 

--- a/lib/virgilio.js
+++ b/lib/virgilio.js
@@ -218,19 +218,18 @@ Virgilio.prototype.shareRequire$ = function shareRequire(name, package) {
     }
 };
 
-//Add custom errors
-Virgilio.prototype.registerError$ = function registerError$(name, init) {
+//**registerError** allows users to easily create new error classes.
+Virgilio.prototype.registerError$ = function registerError$(name, init, Base) {
     if (typeof name === 'function') {
+        Base = init;
         init = name;
         name = init.name;
     }
     this.util$.validateArg('registerError$', 'name', name || null, 'string');
-    this.util$.validateArg('registerError$', 'init', init,
-                           ['function', 'undefined']);
     if (this.baseVirgilio$[name]) {
         throw new this.DuplicateErrorRegistrationError(name);
     }
-    this.baseVirgilio$[name] = util.createCustomError(name, init);
+    this.baseVirgilio$[name] = util.createCustomError(name, init, Base);
 };
 
 module.exports = Virgilio;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgilio",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Virgilio, the next generation module bus",
   "main": "./lib/virgilio.js",
   "directories": {

--- a/tests/registerError.test.js
+++ b/tests/registerError.test.js
@@ -41,6 +41,13 @@ describe('Virgilio.prototype.registerError$()', function() {
         error.arg.must.be('test');
     });
 
+    it('Can create an error that extends another error', function() {
+        function BaseError() {}
+        virgilio.registerError$('FooError', null, BaseError);
+        var error = new virgilio.FooError();
+        error.must.be.instanceof(BaseError);
+    });
+
     it('Cannot register an error with the same name twice', function() {
         function testFunc() {
             virgilio.registerError$('FooError', function() {});


### PR DESCRIPTION
When registering an error, it is nice to be able to provide a 'supererror' that this error should extend.
