### PR TITLE
Aditional validation

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -15,6 +15,9 @@ var errors = [
             'Duplicate Error type: `%s`'
         ].join(' ');
         this.message = nodeUtil.format(message, [errorName]);
+    },
+    function UnexpectedExtensionError(methodName) {
+        this.message = nodeUtil.format('Method "%s" cannot be extended.', methodName);
     }
 ];
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -17,7 +17,7 @@ var errors = [
         this.message = nodeUtil.format(message, [errorName]);
     },
     function UnexpectedExtensionError(methodName) {
-        this.message = nodeUtil.format('Method "%s" cannot be extended.', methodName);
+        this.message = nodeUtil.format('Method \'%s\' cannot be extended.', methodName);
     }
 ];
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,7 +63,7 @@ function validateArg(methodName, argName, arg, types) {
 
 function validateNamespaceName(namespace) {
     var namespaceReg = /^\w(\w*\.?(?=\w)\w*)*$/; // just simple & visible names like "foo.bar.baz"
-    if (typeof namespace === "string" && namespaceReg.test(namespace)) {
+    if (typeof namespace === 'string' && namespaceReg.test(namespace)) {
         return true;
     }
     throw new InvalidNamespaceNameError(namespace);

--- a/lib/util.js
+++ b/lib/util.js
@@ -46,7 +46,7 @@ var InvalidArgumentsError = createCustomError(
 var InvalidNamespaceNameError = createCustomError(
     'InvalidNamespaceNameError',
     function(namespace) {
-        var message = 'Invalid namespace name "%s"';
+        var message = 'Invalid namespace name \'%s\'';
         this.message = util.format(message, namespace);
     }
 );
@@ -62,7 +62,7 @@ function validateArg(methodName, argName, arg, types) {
 }
 
 function validateNamespaceName(namespace) {
-    var namespaceReg = /^\w(\w*\.?(?=\w)\w*)*$/; // just simple & visible names like "foo.bar.baz"
+    var namespaceReg = /^\w(\w*\.?(?=\w)\w*)*$/; // just simple & visible names like 'foo.bar.baz'
     if (typeof namespace === 'string' && namespaceReg.test(namespace)) {
         return true;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,7 +62,7 @@ function validateArg(methodName, argName, arg, types) {
 }
 
 function validateNamespaceName(namespace) {
-    var namespaceReg = /^\w(\w*\.?(?=\w)\w*)*$/; // just simple & visible names like 'foo.bar.baz'
+    var namespaceReg = /^\w+(\.\w+)*$/; // just simple & visible names like 'foo.bar.baz'
     if (typeof namespace === 'string' && namespaceReg.test(namespace)) {
         return true;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,8 +43,8 @@ var InvalidArgumentsError = createCustomError(
     }
 );
 
-var InvalidNamespaceName = createCustomError(
-    'InvalidNamespaceName',
+var InvalidNamespaceNameError = createCustomError(
+    'InvalidNamespaceNameError',
     function(namespace) {
         var message = 'Invalid namespace name "%s"';
         this.message = util.format(message, namespace);
@@ -66,7 +66,7 @@ function validateNamespaceName(namespace) {
     if (typeof namespace === "string" && namespaceReg.test(namespace)) {
         return true;
     }
-    throw new InvalidNamespaceName(namespace);
+    throw new InvalidNamespaceNameError(namespace);
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,6 +43,14 @@ var InvalidArgumentsError = createCustomError(
     }
 );
 
+var InvalidNamespaceName = createCustomError(
+    'InvalidNamespaceName',
+    function(namespace) {
+        var message = 'Invalid namespace name "%s"';
+        this.message = util.format(message, namespace);
+    }
+);
+
 function validateArg(methodName, argName, arg, types) {
     if (!util.isArray(types)) {
         types = [types];
@@ -53,7 +61,16 @@ function validateArg(methodName, argName, arg, types) {
     }
 }
 
+function validateNamespaceName(namespace) {
+    var namespaceReg = /^\w(\w*\.?(?=\w)\w*)*$/; // just simple & visible names like "foo.bar.baz"
+    if (typeof namespace === "string" && namespaceReg.test(namespace)) {
+        return true;
+    }
+    throw new InvalidNamespaceName(namespace);
+}
+
 
 exports.extend = extend;
 exports.createCustomError = createCustomError;
 exports.validateArg = validateArg;
+exports.validateNamespaceName = validateNamespaceName;

--- a/lib/virgilio.js
+++ b/lib/virgilio.js
@@ -131,6 +131,7 @@ Virgilio.prototype.namespace$ = function namespace$(path) {
         //Return the current namespace.
         return this;
     }
+    this.util$.validateNamespaceName(path);
     var namespaceStack = path.split('.').reverse();
     //Get the head of the namespace stack. This is not always a child of `this`.
     var name = namespaceStack.pop();

--- a/lib/virgilio.js
+++ b/lib/virgilio.js
@@ -194,7 +194,7 @@ Virgilio.prototype.extend$ = function extend$(methodName, replacementMethod) {
 
 
     var realMethod = Virgilio.prototype[methodName];
-    if (typeof realMethod != "function") {
+    if (typeof realMethod != 'function') {
         throw new this.UnexpectedExtensionError(methodName);
     }
 

--- a/lib/virgilio.js
+++ b/lib/virgilio.js
@@ -191,8 +191,16 @@ Virgilio.prototype.extend$ = function extend$(methodName, replacementMethod) {
                            'string');
     this.util$.validateArg('extend$', 'replacementMethod', replacementMethod,
                            'function');
+
+
+    var realMethod = Virgilio.prototype[methodName];
+    if (typeof realMethod != "function") {
+        throw new this.UnexpectedExtensionError(methodName);
+    }
+
     //Store a reference to the super method.
     var superMethod = this[methodName];
+
     replacementMethod.super$ = superMethod;
     this[methodName] = replacementMethod;
     return this;

--- a/tests/extend.test.js
+++ b/tests/extend.test.js
@@ -30,7 +30,7 @@ describe('Virgilio.prototype.extend$()', function() {
 
     it('Cannot override everything', function() {
         var illegalExtension = function() {
-            virgilio.extend$("foo", function(){} );
+            virgilio.extend$('foo', function(){} );
         };
         virgilio.namespace$('foo');
         illegalExtension.must.throw(virgilio.UnexpectedExtensionError);
@@ -39,7 +39,7 @@ describe('Virgilio.prototype.extend$()', function() {
 
     it('Cannot override non-prototype functions', function() {
         var illegalExtension = function() {
-            virgilio.extend$("foo", function(){} );
+            virgilio.extend$('foo', function(){} );
         };
         virgilio.foo = function() {};
         illegalExtension.must.throw(virgilio.UnexpectedExtensionError);

--- a/tests/extend.test.js
+++ b/tests/extend.test.js
@@ -28,6 +28,23 @@ describe('Virgilio.prototype.extend$()', function() {
         virgilio.namespace$('bar').must.equal(virgilio.foo.bar);
     });
 
+    it('Cannot override everything', function() {
+        var illegalExtension = function() {
+            virgilio.extend$("foo", function(){} );
+        };
+        virgilio.namespace$('foo');
+        illegalExtension.must.throw(virgilio.UnexpectedExtensionError);
+    });
+
+
+    it('Cannot override non-prototype functions', function() {
+        var illegalExtension = function() {
+            virgilio.extend$("foo", function(){} );
+        };
+        virgilio.foo = function() {};
+        illegalExtension.must.throw(virgilio.UnexpectedExtensionError);
+    });
+
     describe('Throws an error when called with wrong arguments', function() {
         var testCases = [
             [],

--- a/tests/namespaces.test.js
+++ b/tests/namespaces.test.js
@@ -45,10 +45,10 @@ describe('Virgilio.prototype.namespace$()', function() {
         it('can use valid namespace', function() {
             var validator = virgilio.util$.validateNamespaceName;
 
-            validator("foo.bar").must.be.true();
-            validator("foo.bar.baz").must.be.true();
-            validator("f.b").must.be.true();
-            validator("f.b.b").must.be.true();
+            validator('foo.bar').must.be.true();
+            validator('foo.bar.baz').must.be.true();
+            validator('f.b').must.be.true();
+            validator('f.b.b').must.be.true();
         });
 
         it('cannot be empty namespace', function() {
@@ -59,8 +59,8 @@ describe('Virgilio.prototype.namespace$()', function() {
                     }
                 };
 
-            wrapper("").must.throw(/^Invalid namespace name .*/);
-            wrapper(" ").must.throw(/^Invalid namespace name .*/);
+            wrapper('').must.throw(/^Invalid namespace name .*/);
+            wrapper(' ').must.throw(/^Invalid namespace name .*/);
         });
 
         it ('cannot use invalid namespaces', function() {
@@ -71,13 +71,13 @@ describe('Virgilio.prototype.namespace$()', function() {
                     }
                 };
 
-            wrapper(".").must.throw(/^Invalid namespace name .*/);
-            wrapper("...").must.throw(/^Invalid namespace name .*/);
-            wrapper(".foo").must.throw(/^Invalid namespace name .*/);
-            wrapper("...foo").must.throw(/^Invalid namespace name .*/);
-            wrapper("foo.").must.throw(/^Invalid namespace name .*/);
-            wrapper("foo...").must.throw(/^Invalid namespace name .*/);
-            wrapper("foo...bar").must.throw(/^Invalid namespace name .*/);
+            wrapper('.').must.throw(/^Invalid namespace name .*/);
+            wrapper('...').must.throw(/^Invalid namespace name .*/);
+            wrapper('.foo').must.throw(/^Invalid namespace name .*/);
+            wrapper('...foo').must.throw(/^Invalid namespace name .*/);
+            wrapper('foo.').must.throw(/^Invalid namespace name .*/);
+            wrapper('foo...').must.throw(/^Invalid namespace name .*/);
+            wrapper('foo...bar').must.throw(/^Invalid namespace name .*/);
         });
 
     });

--- a/tests/namespaces.test.js
+++ b/tests/namespaces.test.js
@@ -34,6 +34,54 @@ describe('Virgilio.prototype.namespace$()', function() {
         testFunc.must.throw(virgilio.IllegalNamespaceError);
     });
 
+    describe('Test namespace validator', function() {
+
+        it('can use simple words as a namespace', function() {
+            var validator = virgilio.util$.validateNamespaceName;
+            validator('foo').must.be.true();
+            validator('f').must.be.true();
+        });
+
+        it('can use valid namespace', function() {
+            var validator = virgilio.util$.validateNamespaceName;
+
+            validator("foo.bar").must.be.true();
+            validator("foo.bar.baz").must.be.true();
+            validator("f.b").must.be.true();
+            validator("f.b.b").must.be.true();
+        });
+
+        it('cannot be empty namespace', function() {
+            var validator = virgilio.util$.validateNamespaceName,
+                wrapper = function(path) {
+                    return function() {
+                        return validator(path);
+                    }
+                };
+
+            wrapper("").must.throw(/^Invalid namespace name .*/);
+            wrapper(" ").must.throw(/^Invalid namespace name .*/);
+        });
+
+        it ('cannot use invalid namespaces', function() {
+            var validator = virgilio.util$.validateNamespaceName,
+                wrapper = function(path) {
+                    return function() {
+                        return validator(path);
+                    }
+                };
+
+            wrapper(".").must.throw(/^Invalid namespace name .*/);
+            wrapper("...").must.throw(/^Invalid namespace name .*/);
+            wrapper(".foo").must.throw(/^Invalid namespace name .*/);
+            wrapper("...foo").must.throw(/^Invalid namespace name .*/);
+            wrapper("foo.").must.throw(/^Invalid namespace name .*/);
+            wrapper("foo...").must.throw(/^Invalid namespace name .*/);
+            wrapper("foo...bar").must.throw(/^Invalid namespace name .*/);
+        });
+
+    });
+
     describe('Throws an error when called with wrong arguments', function() {
         var testCases = [
             [],


### PR DESCRIPTION
* ```Virgilio.prototype.namespace$``` was able to create namespaces without name, so I added namespace name validator to check it. 
* Any Virgilio method or property could be changed with ```Virgilio.prototype.extend$```, including namespaces