### PR TITLE
Improved namespace prototype chain creation.

### DIFF
--- a/lib/virgilio.js
+++ b/lib/virgilio.js
@@ -112,17 +112,6 @@ Virgilio.prototype._createAction$ = function _createAction$(name, handler) {
 
 //## Namespaces
 
-//Namespace instances are proxies for the origin virgilio instance.
-//The createNamespace$ function creates them and sets their prototype to their
-//parent namespace.
-var Namespace = function Namespace(parent, name) {
-    this.path$ = parent.path$ + (name ? ('.' + name) : '');
-    this.parent$ = parent;
-    //Create a bunyan childlogger for this namespace,
-    //to automatically contextualize all logging.
-    this.log$ = this.log$.child({ context: this.path$ });
-};
-
 //**namespace** returns a namespace instance belonging to a path.
 //If that namespace doesn't exist, it is created.
 Virgilio.prototype.namespace$ = function namespace$(path) {
@@ -168,9 +157,13 @@ Virgilio.prototype._createNamespace$ = function _createNamespace$(name) {
     if (this.hasOwnProperty(name)) {
         throw new this.IllegalNamespaceError(this.path$, name);
     }
-    //Let the namespace instance inherit virgilio's methods.
-    Namespace.prototype = this;
-    var namespace = new Namespace(this, name);
+    var path = this.path$ + (name ? ('.' + name) : '');
+    //Create a new namespace that inherits from the current namespace.
+    var namespace = Object.create(this);
+    namespace.path$ = path;
+    namespace.parent$ = this;
+    //Create a bunyan childlogger for this namespace, for contextualized logs.
+    namespace.log$ = this.log$.child({ context: path });
     if (name) {
         this[name] = namespace;
     }
@@ -191,7 +184,6 @@ Virgilio.prototype.extend$ = function extend$(methodName, replacementMethod) {
                            'string');
     this.util$.validateArg('extend$', 'replacementMethod', replacementMethod,
                            'function');
-
 
     var realMethod = Virgilio.prototype[methodName];
     if (typeof realMethod !== 'function') {


### PR DESCRIPTION
To create the namespaces in a prototypechain, previously a `Namespace`
constructor was used, of which the `prototype` property was constantly
reassigned for each newly created namespace.

By using `Object.create()` this is no longer necessary, with cleaner
code as a result.